### PR TITLE
Feature: Docker support, and download script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[codz]
+*$py.class
+
+# virtual env files
+.venv/
+
+# Installer logs
+pip-log.txt
+
+# dump folder
+dumps.wikimedia.org/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.9-slim
+
+# Install system dependencies required by wikiextractor and the download script
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    gcc \
+    g++ \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application scripts
+COPY gather_wordfreq.py .
+COPY wiki-dump.sh .
+RUN chmod +x wiki-dump.sh
+
+# Create a data directory and set it as the default working directory
+WORKDIR /data

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The script was inspired by [this article](http://imonad.com/seo/wikipedia-word-f
 ### Option 1: Docker (Recommended)
 Using Docker is the easiest way to run this project. It handles all dependencies, bypasses OS-specific bugs (like the macOS Python 3.8 issue), and uses Docker volumes to safely manage the large dump files.
 
-#### 1.Build the Docker Image
+#### 1. Build the Docker Image
 From the root of your project directory, run:
 
 ```sh
@@ -33,8 +33,9 @@ Parse dumps and save results:
 
 ```sh
 docker run -v $(pwd)/output:/data wiki-wordfreq python /app/gather_wordfreq.py /data/dumps.wikimedia.org/enwiki/latest/*.bz2 > output/wordfreq.txt
-(Note: You can change enwiki to any other language code, like dewiki or frwiki, in both commands).
 ```
+
+You can change `enwiki` to any other language code, like `dewiki` or `frwiki`, in both commands.
 
 ### Option 2: Local Installation
 
@@ -54,13 +55,12 @@ Download the current Wikipedia dumps for the desired language:
 
 (You can also use the raw wget command directly if you prefer).
 
-
 _Note that for enwiki (as of April 2023) this will require about 19 Gb of free space._
 
 Parse dumps and save results:
 
 ```sh
-python ./gather_wordfreq.py dumps.wikimedia.org/${WIKI}/latest/*.bz2 > wordfreq.txt
+python ./gather_wordfreq.py dumps.wikimedia.org/${WIKI:-enwiki}/latest/*.bz2 > wordfreq.txt
 ```
 
 ## Pre-generated word frequency data
@@ -90,4 +90,4 @@ Word frequency data for the following languages is available in [results](result
 English results:
 
 * Total unique words appearing at least in 3 articles: 2747823
-* Top 20 most popular words: the, of, in, and, a, to, was, is, on, for, as, with, by, he, that, at, from, his, it, an.
+* Top 20 most popular words: the, of, in, and, a, to, was, is, on, for, as, with, by, he, that, at, from, his, it, an.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,38 @@ The script was inspired by [this article](http://imonad.com/seo/wikipedia-word-f
 
 ## Usage
 
+### Option 1: Docker (Recommended)
+Using Docker is the easiest way to run this project. It handles all dependencies, bypasses OS-specific bugs (like the macOS Python 3.8 issue), and uses Docker volumes to safely manage the large dump files.
+
+#### 1.Build the Docker Image
+From the root of your project directory, run:
+
+```sh
+docker build -t wiki-wordfreq .
+```
+
+#### 2. Run the Container
+Because Wikipedia dumps are huge (e.g., ~19 GB for English), we mount a local ./output directory to the container using -v. This ensures your hard drive doesn't fill up the Docker internal storage and allows you to easily access the results.
+
+Download the current Wikipedia dumps:
+
+```sh
+# Create a local output directory
+mkdir -p output
+
+# Run the download script (e.g., for English Wikipedia)
+docker run -v $(pwd)/output:/data wiki-wordfreq /app/wiki-dump.sh --wiki enwiki
+```
+
+Parse dumps and save results:
+
+```sh
+docker run -v $(pwd)/output:/data wiki-wordfreq python /app/gather_wordfreq.py /data/dumps.wikimedia.org/enwiki/latest/*.bz2 > output/wordfreq.txt
+(Note: You can change enwiki to any other language code, like dewiki or frwiki, in both commands).
+```
+
+### Option 2: Local Installation
+
 The script needs Python 3. On macOS, [there is a known bug with Python 3.8](https://github.com/GoogleCloudPlatform/gsutil/issues/961#issuecomment-604648510), so you will need to use Python 3.7 or lower.
 
 Install requirements:
@@ -17,11 +49,11 @@ pip install -r requirements.txt
 Download the current Wikipedia dumps for the desired language:
 
 ```sh
-WIKI=enwiki
-wget -np -r --accept-regex \
-  "https:\/\/dumps\.wikimedia\.org\/${WIKI}\/latest\/${WIKI}-latest-pages-articles[0-9]*\.xml.bz2" \
-  https://dumps.wikimedia.org/${WIKI}/latest/
+./wiki-dump.sh --wiki enwiki
 ```
+
+(You can also use the raw wget command directly if you prefer).
+
 
 _Note that for enwiki (as of April 2023) this will require about 19 Gb of free space._
 

--- a/wiki-dump.sh
+++ b/wiki-dump.sh
@@ -31,10 +31,18 @@ usage() {
 while [[ "$#" -gt 0 ]]; do
     case $1 in
         -w|--wiki)
+            if [[ -z "$2" ]]; then
+                echo "Error: --wiki requires an argument"
+                exit 1
+            fi
             WIKI="$2"
             shift 2
             ;;
         -e|--extra)
+            if [[ -z "$2" ]]; then
+                echo "Error: --extra requires an argument"
+                exit 1
+            fi
             WGET_EXTRA_OPTS="$2"
             shift 2
             ;;
@@ -43,7 +51,7 @@ while [[ "$#" -gt 0 ]]; do
             ;;
         *)
             echo "Error: Unknown parameter passed: $1"
-            usage
+            exit 1
             ;;
     esac
 done

--- a/wiki-dump.sh
+++ b/wiki-dump.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+# ==========================================
+# Default Variables
+# ==========================================
+WIKI="enwiki"
+WGET_EXTRA_OPTS=""
+
+# ==========================================
+# Help Function
+# ==========================================
+usage() {
+    echo "Usage: $0 [OPTIONS]"
+    echo "Downloads the latest Wikipedia pages-articles XML dump."
+    echo ""
+    echo "Options:"
+    echo "  -w, --wiki WIKI       Target wiki project (e.g., enwiki, dewiki, frwiki)."
+    echo "                        Default: $WIKI"
+    echo "  -e, --extra OPTS      Additional wget options (wrap in quotes, e.g., '-c -q')."
+    echo "                        Default: none"
+    echo "  -h, --help            Show this help message and exit"
+    echo ""
+    echo "Example:"
+    echo "  $0 --wiki dewiki --extra '-c'" 
+    exit 0
+}
+
+# ==========================================
+# Argument Parsing
+# ==========================================
+while [[ "$#" -gt 0 ]]; do
+    case $1 in
+        -w|--wiki)
+            WIKI="$2"
+            shift 2
+            ;;
+        -e|--extra)
+            WGET_EXTRA_OPTS="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            ;;
+        *)
+            echo "Error: Unknown parameter passed: $1"
+            usage
+            ;;
+    esac
+done
+
+# ==========================================
+# Construct Regex and Execute
+# ==========================================
+# Note: Removed the unnecessary backslashes before the forward slashes (\/) 
+# as they aren't needed for regex or bash strings.
+REGEX="https://dumps\.wikimedia\.org/${WIKI}/latest/${WIKI}-latest-pages-articles[0-9]*\.xml\.bz2"
+BASE_URL="https://dumps.wikimedia.org/${WIKI}/latest/"
+
+echo "==> Target Wiki: ${WIKI}"
+echo "==> Match Regex: ${REGEX}"
+echo "==> Base URL:    ${BASE_URL}"
+echo "==> Executing wget..."
+
+# We leave $WGET_EXTRA_OPTS unquoted so it correctly splits into separate arguments
+wget -np -r --accept-regex "$REGEX" $WGET_EXTRA_OPTS "$BASE_URL"


### PR DESCRIPTION
This PR simplifies the setup process by Dockerizing the project, and introduces a helper script for downloading Wikipedia dumps.

Changes:

Dockerized the project: Added a Dockerfile to containerize the environment. This resolves OS-specific dependency issues (like the macOS Python 3.8 bug) and handles large dump files cleanly using Docker volumes.
Added wiki-dump.sh script: Created a bash script with optional flags (e.g., --wiki fawiki) to replace the long, copy-pasted wget command, making the download process much more user-friendly.
Updated README.md: Restructured the documentation to feature the Docker workflow as the primary recommended method, while keeping local installation instructions intact.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Dockerizes the project and adds a `wiki-dump.sh` helper to simplify downloading Wikipedia dumps. Standardizes setup across OSes and uses volumes to handle large files.

- **New Features**
  - Added Dockerfile with Python deps/tools; sets `/data` as the default workdir for mounted volumes.
  - Added `wiki-dump.sh` with `--wiki` and `--extra` flags to replace the long `wget` command.
  - Updated README to recommend the Docker workflow with simple run commands; kept local install steps.
  - Updated `.gitignore` for dumps and `.venv`; added example `fawiki` results.

- **Bug Fixes**
  - Cleaned up the dump URL regex and improved CLI validation in `wiki-dump.sh`.

<sup>Written for commit c82cbde1961227a96c03929baa5363051b75db8f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

